### PR TITLE
Avoid multiple calls on callback

### DIFF
--- a/svn.js
+++ b/svn.js
@@ -482,12 +482,14 @@ svn.run = function(args, callback, cwd) {
 	proc.on('error', function(error) {
 		var result = null;
 		err = new Error('[SVN ERROR:404] svn command not found');
-		if (error.code === 'ENOENT' && callback) {
-			result = callback(err);
+		if (error.code === 'ENOENT') {
+			// Force kill now. Callback will be executed when `ChildProcess#close` will be emitted
+			proc.kill('ENOENT');
+			return;
 		}
 		p.done(err, result);
 	});
-
+	
 	proc.on('close', function(code) {
 		var result = null;
 		if (callback) {


### PR DESCRIPTION
Please note that this modification is not deeply tested. It was done to solve a SINGLE incorrect behavior, so I don't know if it will still behave normally in other situation.

The problem was that if SVN is not installed/found, `callback` was called on `ChildProcess#error` but also when the process run normally `ChildProcess#close`. Now callback is run only when process leave stdio.

I repeat that this is absolutelly not tested in every case, but it seems coherent.

Also, can you update NPM package to integrate my previous changes & generate documentation?

Thanks
